### PR TITLE
fix opengl and add developer name

### DIFF
--- a/org.srb2.SRB2Kart.metainfo.xml
+++ b/org.srb2.SRB2Kart.metainfo.xml
@@ -23,6 +23,7 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://wiki.srb2.org/wiki/SRB2Kart</url>
+  <developer_name>Kart Krew team</developer_name>
   <provides>
     <binary>srb2kart</binary>
   </provides>

--- a/org.srb2.SRB2Kart.metainfo.xml
+++ b/org.srb2.SRB2Kart.metainfo.xml
@@ -23,7 +23,7 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://wiki.srb2.org/wiki/SRB2Kart</url>
-  <developer_name>Kart Krew team</developer_name>
+  <developer_name>Kart Krew</developer_name>
   <provides>
     <binary>srb2kart</binary>
   </provides>

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -59,6 +59,9 @@ modules:
         path: org.srb2.SRB2Kart.desktop
       - type: file
         path: org.srb2.SRB2Kart.metainfo.xml
+      - type: patch
+        path: r_opengl.patch
+        strip-components: 0
 
   - name: srb2kart-assets
     buildsystem: simple

--- a/r_opengl.patch
+++ b/r_opengl.patch
@@ -1,0 +1,17 @@
+--- src/hardware/r_opengl/r_opengl.c.old	2020-05-11 23:31:38.000000000 -0400
++++ src/hardware/r_opengl/r_opengl.c	2020-05-20 15:40:58.466898373 -0400
+@@ -142,13 +142,13 @@
+ // Returns          :
+ // -----------------+
+ 
+-#ifdef DEBUG_TO_FILE
++#if 0
+ FILE *gllogstream;
+ #endif
+ 
+ FUNCPRINTF void GL_DBG_Printf(const char *format, ...)
+ {
+-#ifdef DEBUG_TO_FILE
++#if 0
+ 	char str[4096] = "";
+ 	va_list arglist;


### PR DESCRIPTION
turn off `gllog` so that  opengl works (#2) and add developer name to the metadata