### PR TITLE
longer captions for images

### DIFF
--- a/org.srb2.SRB2Kart.metainfo.xml
+++ b/org.srb2.SRB2Kart.metainfo.xml
@@ -27,19 +27,19 @@
     </screenshot>
     <screenshot>
       <image>https://user-images.githubusercontent.com/1964655/82821921-3d180c00-9ea5-11ea-937b-e1f53fe6c686.png</image>
-      <caption>Sonic</caption>
+      <caption>Game play as Sonic</caption>
     </screenshot>
     <screenshot>
       <image>https://user-images.githubusercontent.com/1964655/82821933-41442980-9ea5-11ea-9146-38998161edae.png</image>
-      <caption>Tails</caption>
+      <caption>Game play as Tails</caption>
     </screenshot>
     <screenshot>
       <image>https://user-images.githubusercontent.com/1964655/82821966-502adc00-9ea5-11ea-9cbd-274d7adb479e.png</image>
-      <caption>Eggman</caption>
+      <caption>Game play as Eggman</caption>
     </screenshot>
     <screenshot>
       <image>https://user-images.githubusercontent.com/1964655/82821980-5620bd00-9ea5-11ea-9eec-2835ebb2a262.png</image>
-      <caption>Metal Sonic</caption>
+      <caption>Game play as Metal Sonic</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://wiki.srb2.org/wiki/SRB2Kart</url>


### PR DESCRIPTION
`appstream-util validate` was failing.  Fixes #10.