### PR TITLE
Add support for normal discord

### DIFF
--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --device=all
   - --persist=.srb2kart
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/discord-ipc-0
 modules:
   - shared-modules/glu/glu-9.json
 


### PR DESCRIPTION
Apparently the instructions on the flatpak discord wiki only work **for** flatpak discord and nobody said anything