### PR TITLE
Disable wayland because it crashes with it enabled

### DIFF
--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -6,9 +6,8 @@ command: srb2kart
 finish-args:
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=pulseaudio
-  - --socket=wayland
   - --device=all
   - --persist=.srb2kart
   - --filesystem=xdg-run/app/com.discordapp.Discord:create


### PR DESCRIPTION
For me, on Fedora 36 KDE, it crashes in Wayland if the wayland socket is enabled.