### PR TITLE
Fix .mx music

### DIFF
--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -42,6 +42,10 @@ modules:
       - type: archive
         url: https://sitsa.dl.sourceforge.net/project/modplug-xmms/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz
         sha256: 77462d12ee99476c8645cb5511363e3906b88b33a6b54362b4dbc0f39aa2daad
+        x-checker-data:
+          type: anitya
+          project-id: 5669
+          url-template: https://sourceforge.net/projects/modplug-xmms/files/libmodplug/$version/libmodplug-$version.tar.gz
 
   - name: sdl-mixer
     buildsystem: autotools

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -32,6 +32,29 @@ modules:
           stable-only: true
           url-template: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-$version.tar.xz
 
+  - name: libmodplug
+    buildsystem: autotools
+    cleanup:
+      - /include
+      - /lib/*.la
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://sitsa.dl.sourceforge.net/project/modplug-xmms/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz
+        sha256: 77462d12ee99476c8645cb5511363e3906b88b33a6b54362b4dbc0f39aa2daad
+
+  - name: sdl-mixer
+    buildsystem: autotools
+    cleanup:
+      - /include
+      - /lib/*.la
+      - /lib/*.a
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-2.0.4.tar.gz
+        sha256: 5605b6f230717acf6d09549671f7fe03f006700c61a61b86042888f81792e2b3
+
   - name: rapidjson
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Rebuild sdl-mixer with libmodplug to be able to play .mx files. Fixes the music on Kodachrome Void (map36) and any other map that would use the same file format.
