### PR TITLE
Use MAME YM2612 emulator

### DIFF
--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -34,6 +34,9 @@ modules:
       - /include
       - /lib/*.so
       - /lib/pkgconfig
+    config-opts:
+      - -DGME_YM2612_EMU=MAME
+      - -DENABLE_UBSAN=OFF
     sources:
       - type: archive
         url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz


### PR DESCRIPTION
The Nuked emulator (default in libgme) is far too intensive to be used in a game's audio mixer, and in particular it performs very poorly on Steam Deck. We use the MAME emulator for Windows builds because of this, but this flatpak currently uses Nuked.