### PR TITLE
Migrate gamescope library to supported namespace

### DIFF
--- a/org.srb2.SRB2Kart.desktop
+++ b/org.srb2.SRB2Kart.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version=1.6
 Type=Application
 Name=Sonic Robo Blast 2 Kart
 Comment=A kart racing mod based on the 3D Sonic the Hedgehog fangame Sonic Robo Blast 2

--- a/org.srb2.SRB2Kart.desktop
+++ b/org.srb2.SRB2Kart.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.6
+Version=1.0
 Type=Application
 Name=Sonic Robo Blast 2 Kart
 Comment=A kart racing mod based on the 3D Sonic the Hedgehog fangame Sonic Robo Blast 2

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -14,7 +14,7 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
   - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
-  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib/extensions/vulkan/gamescope/lib
+  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib:/usr/lib/extensions/vulkan/gamescope/lib
 
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -16,11 +16,11 @@ finish-args:
 
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
-    version: stable
-    add-ld-path: lib
-    no-autodownload: true
-    autodelete: true
     directory: utils/gamescope
+    version: '25.08'
+    add-ld-path: lib
+    no-autodownload: false
+    autodelete: true
 
 cleanup-commands:
   - mkdir -p /app/utils/gamescope

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -31,7 +31,6 @@ cleanup:
   - "/include"
   - "/lib/cmake"
   - "/lib/pkgconfig"
-  - "/share/man"
   - "*.la"
   - "*.a"
 

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -51,10 +51,6 @@ modules:
     buildsystem: autotools
     build-options:
       cxxflags: "-O3 -Wno-register"
-    cleanup:
-      - /include
-      - /lib/*.la
-      - /lib/pkgconfig
     sources:
       - type: archive
         url: https://sourceforge.net/projects/modplug-xmms/files/libmodplug/0.8.9.0/libmodplug-0.8.9.0.tar.gz
@@ -67,10 +63,6 @@ modules:
   - name: sdl2-mixer
     buildsystem: autotools
     cleanup:
-      - /include
-      - /lib/*.la
-      - /lib/*.a
-      - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
@@ -90,9 +82,6 @@ modules:
       - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - -DCMAKE_INSTALL_LIBDIR=lib
     cleanup:
-      - /include
-      - /lib/cmake
-      - /lib/pkgconfig
       - /share/doc
     sources:
       - type: archive
@@ -109,8 +98,6 @@ modules:
       - -DBUILD_EXAMPLES=OFF
       - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - -DCMAKE_INSTALL_LIBDIR=lib
-    cleanup:
-      - /include
     sources:
       - type: git
         url: https://github.com/discord/discord-rpc.git

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -62,7 +62,6 @@ modules:
 
   - name: sdl2-mixer
     buildsystem: autotools
-    cleanup:
     sources:
       - type: archive
         url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -14,7 +14,6 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
   - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
-  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib:/usr/lib/extensions/vulkan/gamescope/lib
 
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
@@ -23,9 +22,6 @@ add-extensions:
     add-ld-path: lib
     no-autodownload: true
     autodelete: true
-
-cleanup-commands:
-  - mkdir -p /app/lib/extensions/vulkan/gamescope
 
 cleanup:
   - "/include"

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -13,13 +13,13 @@ finish-args:
   - --persist=.srb2kart
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
-  - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin # hacks for gamescope
-  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib/extensions/vulkan/gamescope/lib # ALSO hacks for gamescope...
+  - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
+  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib/extensions/vulkan/gamescope/lib
 
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
     directory: lib/extensions/vulkan/gamescope
-    version: '25.08' 
+    version: 'stable' 
     add-ld-path: lib
     no-autodownload: true
     autodelete: true
@@ -41,10 +41,6 @@ modules:
     buildsystem: cmake-ninja
     config-opts: 
       - -DCMAKE_INSTALL_LIBDIR=lib
-    # cleanup:
-    #   - /include
-    #   - /lib/*.so
-    #   - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/libgme/game-music-emu/releases/download/0.6.4/libgme-0.6.4-src.tar.gz
@@ -58,7 +54,7 @@ modules:
   - name: libmodplug
     buildsystem: autotools
     build-options:
-      cxxflags: "-O3 -Wno-register" # for fastmix logs because c17 std doesnt like usage of `register`
+      cxxflags: "-O3 -Wno-register"
     cleanup:
       - /include
       - /lib/*.la
@@ -102,15 +98,6 @@ modules:
       - /lib/cmake
       - /lib/pkgconfig
       - /share/doc
-    # sources:
-    #   - type: archive
-    #     url: https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz
-    #     sha256: bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
-    #     x-checker-data:
-    #       type: anitya
-    #       project-id: 7422
-    #       stable-only: true
-    #       url-template: https://github.com/Tencent/rapidjson/archive/refs/tags/v$version.tar.gz
     sources:
       - type: archive
         # latest commit as of 2026-02

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -13,23 +13,20 @@ finish-args:
   - --persist=.srb2kart
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
+  - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
 
 add-extensions:
-  com.valvesoftware.Steam.Utility.gamescope:
-    version: stable
+  org.freedesktop.Platform.VulkanLayer.gamescope:
+    directory: lib/extensions/vulkan/gamescope
+    version: 'stable' 
     add-ld-path: lib
     no-autodownload: true
     autodelete: true
-    directory: utils/gamescope
-
-cleanup-commands:
-  - mkdir -p /app/utils/gamescope
 
 cleanup:
   - "/include"
   - "/lib/cmake"
   - "/lib/pkgconfig"
-  - "/share/man"
   - "*.la"
   - "*.a"
 
@@ -40,10 +37,6 @@ modules:
     buildsystem: cmake-ninja
     config-opts: 
       - -DCMAKE_INSTALL_LIBDIR=lib
-    # cleanup:
-    #   - /include
-    #   - /lib/*.so
-    #   - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/libgme/game-music-emu/releases/download/0.6.4/libgme-0.6.4-src.tar.gz
@@ -56,10 +49,8 @@ modules:
 
   - name: libmodplug
     buildsystem: autotools
-    cleanup:
-      - /include
-      - /lib/*.la
-      - /lib/pkgconfig
+    build-options:
+      cxxflags: "-O3 -Wno-register"
     sources:
       - type: archive
         url: https://sourceforge.net/projects/modplug-xmms/files/libmodplug/0.8.9.0/libmodplug-0.8.9.0.tar.gz
@@ -71,11 +62,6 @@ modules:
 
   - name: sdl2-mixer
     buildsystem: autotools
-    cleanup:
-      - /include
-      - /lib/*.la
-      - /lib/*.a
-      - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
@@ -95,19 +81,7 @@ modules:
       - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - -DCMAKE_INSTALL_LIBDIR=lib
     cleanup:
-      - /include
-      - /lib/cmake
-      - /lib/pkgconfig
       - /share/doc
-    # sources:
-    #   - type: archive
-    #     url: https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz
-    #     sha256: bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
-    #     x-checker-data:
-    #       type: anitya
-    #       project-id: 7422
-    #       stable-only: true
-    #       url-template: https://github.com/Tencent/rapidjson/archive/refs/tags/v$version.tar.gz
     sources:
       - type: archive
         # latest commit as of 2026-02
@@ -123,8 +97,6 @@ modules:
       - -DBUILD_EXAMPLES=OFF
       - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - -DCMAKE_INSTALL_LIBDIR=lib
-    cleanup:
-      - /include
     sources:
       - type: git
         url: https://github.com/discord/discord-rpc.git
@@ -152,10 +124,7 @@ modules:
     build-commands:
       - >
         make -C src -j $FLATPAK_BUILDER_N_JOBS 
-        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1 
-        HAVE_GME=1 GME_CFLAGS="-I/app/include" GME_LDFLAGS="-L/app/lib -lgme"
-        HAVE_LIBXMP=1 LIBXMP_CFLAGS="-I/app/include" LIBXMP_LDFLAGS="-L/app/lib -lxmp"
-        HAVE_FLUIDSYNTH=1 FLUID_CFLAGS="-I/app/include" FLUID_LDFLAGS="-L/app/lib -lfluidsynth"
+        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1
         $ARCH_MAKE_ARGS
       - install -D -m 755 bin/Linux*/Release/lsdl2srb2kart $FLATPAK_DEST/bin/srb2kart
       - install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -21,7 +21,7 @@ add-extensions:
     directory: lib/extensions/vulkan/gamescope
     version: '25.08' 
     add-ld-path: lib
-    no-autodownload: false
+    no-autodownload: true
     autodelete: true
 
 cleanup-commands:

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -152,10 +152,7 @@ modules:
     build-commands:
       - >
         make -C src -j $FLATPAK_BUILDER_N_JOBS 
-        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1 
-        HAVE_GME=1 GME_CFLAGS="-I/app/include" GME_LDFLAGS="-L/app/lib -lgme"
-        HAVE_LIBXMP=1 LIBXMP_CFLAGS="-I/app/include" LIBXMP_LDFLAGS="-L/app/lib -lxmp"
-        HAVE_FLUIDSYNTH=1 FLUID_CFLAGS="-I/app/include" FLUID_LDFLAGS="-L/app/lib -lfluidsynth"
+        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1
         $ARCH_MAKE_ARGS
       - install -D -m 755 bin/Linux*/Release/lsdl2srb2kart $FLATPAK_DEST/bin/srb2kart
       - install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -58,6 +58,8 @@ modules:
 
   - name: libmodplug
     buildsystem: autotools
+    build-options:
+      cxxflags: "-O3 -Wno-register" # for fastmix logs because c17 std doesnt like usage of `register`
     cleanup:
       - /include
       - /lib/*.la

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -19,7 +19,7 @@ add-extensions:
     directory: utils/gamescope
     version: '25.08'
     add-ld-path: lib
-    no-autodownload: false
+    no-autodownload: true
     autodelete: true
 
 cleanup-commands:

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -15,7 +15,7 @@ finish-args:
   - --filesystem=xdg-run/discord-ipc-0
 
 add-extensions:
-  com.valvesoftware.Steam.Utility.gamescope:
+  org.freedesktop.Platform.VulkanLayer.gamescope:
     version: stable
     add-ld-path: lib
     no-autodownload: true

--- a/org.srb2.SRB2Kart.yaml
+++ b/org.srb2.SRB2Kart.yaml
@@ -13,17 +13,19 @@ finish-args:
   - --persist=.srb2kart
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
+  - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin # hacks for gamescope
+  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib/extensions/vulkan/gamescope/lib # ALSO hacks for gamescope...
 
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
-    directory: utils/gamescope
-    version: '25.08'
+    directory: lib/extensions/vulkan/gamescope
+    version: '25.08' 
     add-ld-path: lib
-    no-autodownload: true
+    no-autodownload: false
     autodelete: true
 
 cleanup-commands:
-  - mkdir -p /app/utils/gamescope
+  - mkdir -p /app/lib/extensions/vulkan/gamescope
 
 cleanup:
   - "/include"

--- a/srb2kart.sh
+++ b/srb2kart.sh
@@ -4,7 +4,7 @@ for i in {0..9}; do
 	test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-export PATH="/app/utils/gamescope/bin:$PATH"
+export PATH="/app/lib/extensions/vulkan/gamescope/bin:$PATH"
 export SRB2WADDIR=/app/extra
 
 if [ -z "$GAMESCOPE_ARGS" ]; then


### PR DESCRIPTION
apparently the old `com.valvesoftware.Steam.Utility.gamescope` library is deprecated and the old namespace was recently archived (though it probably still works fine), and was migrated to `org.freedesktop.Platform.VulkanLayer.gamescope` (which receives updates)

this cleans up some unnecessary ENVs (tested and they didn't affect the build or gameplay so I removed them)
and updates gamescope to `org.freedesktop.Platform.VulkanLayer.gamescope`.

unfortunately my Linux hardware (x86_64) didn't cope with gamescope well, and I don't have a Steam deck or any other good hardware to test it, so when gamescope launched it didn't like my hardware (it is very picky with gamescope unfortunately)

thank you