### PR TITLE
Change OARS metadata to align with SRB2

### DIFF
--- a/org.srb2.SRB2Kart.metainfo.xml
+++ b/org.srb2.SRB2Kart.metainfo.xml
@@ -71,7 +71,7 @@
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
-    <content_attribute id="social-chat">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
 </component>


### PR DESCRIPTION
SRB2's OARS rating was [changed a while back](https://github.com/flathub/org.srb2.SRB2/pull/63) to 13+ because of the unmoderated chat functionality.

But on Flathub (apparently they show age ratings from GNOME now as a new feature), SRB2Kart shows:
<img width="1512" height="463" alt="Screenshot 2026-03-30 at 8 51 05 PM" src="https://github.com/user-attachments/assets/d299d7e1-5a64-4085-844e-b2976e015e20" />
despite it also having unmoderated chat, like vanilla SRB2.

Since SRB2Kart also has unmoderated chat, `social-chat` in metadata should probably be changed to intense or moderate.
Thank you